### PR TITLE
Fix call to logging._level

### DIFF
--- a/ina219.py
+++ b/ina219.py
@@ -124,8 +124,8 @@ class INA219:
         log_level -- set to logging.DEBUG to see detailed calibration
             calculations (optional).
         """
-        logging.basicConfig(level=log_level)
         self._log = logging.getLogger("ina219")
+        self._log.setLevel(log_level)
         self._i2c = i2c
         self._address = address
         self._shunt_ohms = shunt_ohms

--- a/ina219.py
+++ b/ina219.py
@@ -406,7 +406,7 @@ class INA219:
 
     def __log_register_operation(self, msg, register, value):
         # performance optimisation
-        if logging._level == logging.DEBUG:
+        if self._log.level == logging.DEBUG:
             binary = '{0:#018b}'.format(value)
             self._log.debug("%s register 0x%02x: 0x%04x %s",
                             msg, register, value, binary)


### PR DESCRIPTION
I just installed your excellent library on an ESP32, and got it working by making this change. I can't say I've read every line of your library and logging.py but it looks like maybe logging._level was removed at some point after you wrote the library?

Anyway I think using self._log.level seems to be the right fix. 